### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/exec_bash_exercise.yml
+++ b/.github/workflows/exec_bash_exercise.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       env:
         SECRET_MESSAGE: ${{ secrets.EXEC_BASH_EXERCISE_SECRET_MESSAGE }}
       with:

--- a/.github/workflows/first_volume_exercise.yml
+++ b/.github/workflows/first_volume_exercise.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       env:
         SECRET_MESSAGE: ${{ secrets.FIRST_VOLUME_EXERCISE_SECRET_MESSAGE }}
       with:

--- a/.github/workflows/ports_exercise.yml
+++ b/.github/workflows/ports_exercise.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: devopsdockeruh/ports_exercise
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore